### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:index, :show, :destroy, :update]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   def index
@@ -17,23 +17,32 @@ class ItemsController < ApplicationController
     else
       render :new
     end
-
   end
 
-  #def destroy
-   # if @item.destroy
+  # def destroy
+  #  if @item.destroy
     #  redirect_to root_path
-    #else
+    # else
     #  render :show
-   # end
-  #end
+  #  end
+  # end
 
   def edit
-    
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def show
     
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params) 
+      redirect_to root_path
+    else 
+      render :edit
+    end
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show, :destroy, :update]
-  before_action :set_item, only: [:edit, :show, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:edit, :show, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -28,7 +28,6 @@ class ItemsController < ApplicationController
   # end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 
@@ -37,12 +36,12 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params) 
       redirect_to root_path
     else 
       render :edit
     end
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :edit]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -36,12 +36,12 @@ class ItemsController < ApplicationController
   end
 
   def update
+    redirect_to root_path unless current_user.id == @item.user_id
     if @item.update(item_params) 
-      redirect_to root_path
+      redirect_to item_path
     else 
       render :edit
     end
-    redirect_to root_path unless current_user.id == @item.user_id
   end
 
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,159 +1,159 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
 
-<%# <div class="items-sell-contents"> %>
-  <%# <header class="items-sell-header"> %>
-    <%# <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %> %>
-  <%# </header> %>
-  <%# <div class="items-sell-main"> %>
-    <%# <h2 class="items-sell-title">商品の情報を入力</h2> %>
-    <%# <%= form_with model: @item, local: true do |f| %> %>
-<%#  %>
-    <%# <%= render 'shared/error_messages', model: f.object %> %>
-<%#  %>
-    出品画像
-    <%# <div class="img-upload"> %>
-      <%# <div class="weight-bold-text"> %>
-        <%# 出品画像 %>
-        <%# <span class="indispensable">必須</span> %>
-      <%# </div> %>
-      <%# <div class="click-upload"> %>
-        <%# <p> %>
-          <%# クリックしてファイルをアップロード %>
-        <%# </p> %>
-        <%# <%= f.file_field :item, id:"item-image" %> %>
-      <%# </div> %>
-    <%# </div> %>
-    /出品画像
-    商品名と商品説明
-    <%# <div class="new-items"> %>
-      <%# <div class="weight-bold-text"> %>
-        <%# 商品名 %>
-        <%# <span class="indispensable">必須</span> %>
-      <%# </div> %>
-      <%# <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> %>
-      <%# <div class="items-explain"> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# 商品の説明 %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> %>
-      <%# </div> %>
-    <%# </div> %>
-    /商品名と商品説明
-<%#  %>
-    商品の詳細
-    <%# <div class="items-detail"> %>
-      <%# <div class="weight-bold-text">商品の詳細</div> %>
-      <%# <div class="form"> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# カテゴリー %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# 商品の状態 %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> %>
-      <%# </div> %>
-    <%# </div> %>
-    /商品の詳細
-<%#  %>
-    配送について
-    <%# <div class="items-detail"> %>
-      <%# <div class="weight-bold-text question-text"> %>
-        <%# <span>配送について</span> %>
-        <%# <a class="question" href="#">?</a> %>
-      <%# </div> %>
-      <%# <div class="form"> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# 配送料の負担 %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# 発送元の地域 %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> %>
-        <%# <div class="weight-bold-text"> %>
-          <%# 発送までの日数 %>
-          <%# <span class="indispensable">必須</span> %>
-        <%# </div> %>
-        <%# <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> %>
-      <%# </div> %>
-    <%# </div> %>
-    /配送について
-<%#  %>
-    販売価格
-    <%# <div class="sell-price"> %>
-      <%# <div class="weight-bold-text question-text"> %>
-        <%# <span>販売価格<br>(¥300〜9,999,999)</span> %>
-        <%# <a class="question" href="#">?</a> %>
-      <%# </div> %>
-      <%# <div> %>
-        <%# <div class="price-content"> %>
-          <%# <div class="price-text"> %>
-            <%# <span>価格</span> %>
-            <%# <span class="indispensable">必須</span> %>
-          <%# </div> %>
-          <%# <span class="sell-yen">¥</span> %>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
-        <%# </div> %>
-        <%# <div class="price-content"> %>
-          <%# <span>販売手数料 (10%)</span> %>
-          <%# <span> %>
-            <%# <span id='add-tax-price'></span>円 %>
-          <%# </span> %>
-        <%# </div> %>
-        <%# <div class="price-content"> %>
-          <%# <span>販売利益</span> %>
-          <%# <span> %>
-            <%# <span id='profit'></span>円 %>
-          <%# </span> %>
-        <%# </div> %>
-      <%# </div> %>
-    <%# </div> %>
-    /販売価格
-<%#  %>
-    注意書き
-    <%# <div class="caution"> %>
-      <%# <p class="sentence"> %>
-        <%# <a href="#">禁止されている出品、</a> %>
-        <%# <a href="#">行為</a> %>
-        <%# を必ずご確認ください。 %>
-      <%# </p> %>
-      <%# <p class="sentence"> %>
-        <%# またブランド品でシリアルナンバー等がある場合はご記載ください。 %>
-        <%# <a href="#">偽ブランドの販売</a> %>
-        <%# は犯罪であり処罰される可能性があります。 %>
-      <%# </p> %>
-      <%# <p class="sentence"> %>
-        <%# また、出品をもちまして %>
-        <%# <a href="#">加盟店規約</a> %>
-        <%# に同意したことになります。 %>
-      <%# </p> %>
-    <%# </div> %>
-    /注意書き
-    下部ボタン
-    <%# <div class="sell-btn-contents"> %>
-      <%# <%= f.submit "変更する" ,class:"sell-btn" %> %>
-      <%# <%=link_to 'もどる', item_path, class:"back-btn" %> %>
-    <%# </div> %>
-    /下部ボタン
-  <%# </div> %>
-  <%# <% end %> %>
-<%#  %>
-  <%# <footer class="items-sell-footer"> %>
-    <%# <ul class="menu"> %>
-      <%# <li><a href="#">プライバシーポリシー</a></li> %>
-      <%# <li><a href="#">フリマ利用規約</a></li> %>
-      <%# <li><a href="#">特定商取引に関する表記</a></li> %>
-    <%# </ul> %>
-    <%# <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %> %>
-    <%# <p class="inc"> %>
-      <%# ©︎Furima,Inc. %>
-    <%# </p> %>
-  <%# </footer> %>
-<%# </div> %>
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with model: @item, local: true do |f| %>
+
+    <%= render 'shared/error_messages', model: f.object %>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :explain, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# <% if @user_item.present? %> %>
+      <%# <% if @user_item.present? %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
-      <%# <% end %> %>
+      <%# <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">


### PR DESCRIPTION
# what
商品情報編集機能の実装

# why
商品情報編集機能を作成するため

●必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
⇒https://gyazo.com/ec260035c8595082931955e17b3b7084
   https://gyazo.com/f89e8620a5a3e497d981eaa253dee895
   
●何も編集せずに更新をしても画像無しの商品にならないこと
●ログイン状態の出品者だけが商品情報編集ページに遷移できること
⇒https://gyazo.com/81f629372c408de60b8fdc7989db3df3
   
●ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
⇒https://gyazo.com/48bfa893557b8518cf7f6bec6e5181ab

●ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
⇒https://gyazo.com/a437d6bc80da068391ac9faefb716164

●商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
⇒https://gyazo.com/38bec5c370a5ec9bbc374b819bba92a3